### PR TITLE
Minor edits to Biopython SeqRecord abstraction idea

### DIFF
--- a/00_ideas.md
+++ b/00_ideas.md
@@ -215,11 +215,11 @@ but is not required, as mock inputs can be used for the project.
 [Kai Blin](https://github.com/kblin), Tilmann Weber
 
 
-### SeqRecord access abstraction layer
+### Biopython SeqRecord access abstraction layer for antiSMASH
 
 #### Rationale
-Internally, antiSMASH uses BioPython SeqRecord objects to handle the data. A lot
-of the annotations are in custom feature entries or in free-text qualifiers of
+Internally, antiSMASH uses [Biopython's SeqRecord objects](http://biopython.org/wiki/SeqRecord)
+to handle the data. A lot of the annotations are in custom feature entries or in free-text qualifiers of
 "gene" or "CDS" features. Code for handling this access is duplicated in parts
 of the code base. Additionally, directly using the SeqRecord object is a bit
 fragile.
@@ -231,8 +231,8 @@ then be utilized to reduce the code duplication and fagility of acessing the
 SeqRecord object special fields.
 
 #### Languages and skill
-antiSMASH is written in Python 2.7. Knowledge of unit testing in Python are a
-plus. Biological knowledge is not required.
+antiSMASH is written in Python 2.7 (while Biopython targets Python 2.7 and 3.3 onward).
+Knowledge of unit testing in Python is a plus. Biological knowledge is not required.
 
 #### Code
 * [Initial implementation of the abstraction


### PR DESCRIPTION
Include Biopython and antiSMASH in the title, Biopython not BioPython, link to SeqRecord webpage.

It was not initially clear to me if this is envisioned as becoming part of Biopython, a separate add-on library, or just internal to antiSMASH.

Unless this is intended for use in antiSMASH only, I think this should target Python 2.7 and 3.3+ at the same time - and also in that case, rather than no biological knowledge, I think it would need a lot of familiarity with sequence annotation to understand why the current SeqRecord object structure is the way it is.